### PR TITLE
add proper use of koala log to subsystems

### DIFF
--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -26,8 +26,8 @@ android {
 
 dependencies {
     implementation project(':FtcRobotController')
-    implementation 'com.github.ori-coval.Koala-Log:KoalaLogger:1.5.3'
-    annotationProcessor 'com.github.ori-coval.Koala-Log:KoalaLoggingProcessor:1.5.3'
+    implementation 'com.github.ori-coval.Koala-Log:KoalaLogger:1.5.5'
+    annotationProcessor 'com.github.ori-coval.Koala-Log:KoalaLoggingProcessor:1.5.5'
 }
 
 repositories {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/lib/builders/DrivetrainBuilder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/lib/builders/DrivetrainBuilder.java
@@ -13,6 +13,8 @@ import org.firstinspires.ftc.teamcode.core.lib.gamepad.GamepadManager;
 import org.firstinspires.ftc.teamcode.core.lib.gamepad.SmartGamepad;
 import org.firstinspires.ftc.teamcode.core.lib.interfaces.Subsystem;
 
+import Ori.Coval.Logging.AutoLog;
+
 
 /**
  * DrivetrainBuilder is a helper class that assists on the creation
@@ -26,8 +28,9 @@ import org.firstinspires.ftc.teamcode.core.lib.interfaces.Subsystem;
  * drivetrains
  * </p>
  */
+@AutoLog
 public class DrivetrainBuilder implements Subsystem {
-    private static DrivetrainBuilder instance;
+    private static DrivetrainBuilderAutoLogged instance;
     private DcMotorSimple.Direction motorRightDirection;
     private DcMotorSimple.Direction motorLeftDirection;
     private String motorLeftName;
@@ -38,7 +41,7 @@ public class DrivetrainBuilder implements Subsystem {
     private Telemetry telemetry;
     private SmartGamepad driver;
 
-    private DrivetrainBuilder() {
+    public DrivetrainBuilder() {
     }
 
     /**
@@ -138,11 +141,11 @@ public class DrivetrainBuilder implements Subsystem {
      * with the getInstance method
      * @return DriveTrainBuilder SingleTon
      */
-    public static DrivetrainBuilder getInstance() {
+    public static DrivetrainBuilderAutoLogged getInstance() {
         if (instance == null) {
-            synchronized (DrivetrainBuilder.class) {
+            synchronized (DrivetrainBuilderAutoLogged.class) {
                 if (instance == null) {
-                    instance = new DrivetrainBuilder();
+                    instance = new DrivetrainBuilderAutoLogged();
                 }
             }
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/subsystems/SubsystemBasicGamepadExample.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/subsystems/SubsystemBasicGamepadExample.java
@@ -18,14 +18,17 @@ import org.firstinspires.ftc.teamcode.core.lib.gamepad.SmartGamepad;
 import org.firstinspires.ftc.teamcode.core.lib.pid.PIDController;
 import org.firstinspires.ftc.teamcode.robot.constants.GlobalConstants;
 
+import Ori.Coval.Logging.AutoLog;
+
 /**
  * Example subsystem that implements the FGCLib.
  * Look at the example to build your own subsystems.
  * This example does the same thing as Subsystem example but
  * without using the GamepadManager portion of the lib
  */
+@AutoLog
 public class SubsystemBasicGamepadExample implements Subsystem {
-    private static SubsystemBasicGamepadExample instance;
+    private static SubsystemBasicGamepadExampleAutoLogged instance;
     private Telemetry telemetry;
     private DcMotor motorRight;
     private DcMotor motorLeft;
@@ -33,7 +36,7 @@ public class SubsystemBasicGamepadExample implements Subsystem {
     private TouchSensor limitLeft;
     private Gamepad operator;
     private org.firstinspires.ftc.teamcode.core.lib.pid.PIDController PIDController;
-    private SubsystemBasicGamepadExample(){
+    public SubsystemBasicGamepadExample(){
 
     }
 
@@ -140,9 +143,9 @@ public class SubsystemBasicGamepadExample implements Subsystem {
      * with the getInstance method
      * @return SubsystemBasicGamepadExample SingleTon
      */
-    public static SubsystemBasicGamepadExample getInstance() {
+    public static SubsystemBasicGamepadExampleAutoLogged getInstance() {
         if (instance == null) {
-            instance = new SubsystemBasicGamepadExample();
+            instance = new SubsystemBasicGamepadExampleAutoLogged();
         }
         return instance;
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/subsystems/SubsystemExample.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/subsystems/SubsystemExample.java
@@ -34,7 +34,7 @@ import Ori.Coval.Logging.AutoLog;
  */
 @AutoLog
 public class SubsystemExample implements Subsystem {
-    private static SubsystemExample instance;
+    private static SubsystemExampleAutoLogged instance;
     private Telemetry telemetry;
     private DcMotor motorRight;
     private DcMotor motorLeft;
@@ -43,7 +43,7 @@ public class SubsystemExample implements Subsystem {
     private SmartGamepad operator;
     private org.firstinspires.ftc.teamcode.core.lib.pid.PIDController PIDController;
 
-    private SubsystemExample() {
+    public SubsystemExample() {
     }
 
     /**
@@ -165,9 +165,9 @@ public class SubsystemExample implements Subsystem {
      * with the getInstance method
      * @return SubsystemExample SingleTon
      */
-    public static synchronized SubsystemExample getInstance() {
+    public static synchronized SubsystemExampleAutoLogged getInstance() {
         if (instance == null) {
-            instance = new SubsystemExample();
+            instance = new SubsystemExampleAutoLogged();
         }
         return instance;
     }


### PR DESCRIPTION
I have added proper use of koala log to the subsystems by adding `@AutoLog` where missing and changing the subsystems that are returned in the singletones to be `...AutoLogged`

for the auto logging to work the constractor of the subsystems has to be public so notice that i have changed it accordingly(this is technically incorrect for a singleton but is the only way for it to work)