### PR TITLE
fix: Remove leftover merge conflict markers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 ![logoTeamBrazil](https://github.com/user-attachments/assets/e4eb1ff4-9f25-475e-837c-5bbe0f090740)
 
 [![Static Badge](https://img.shields.io/badge/pt_br-readme-green)](doc/pt-br/README.md)
@@ -1771,4 +1770,3 @@ Changes include:
  * The API for the Legacy Module and Core Device Interface Module have been updated.
    - Support for encoders with the Legacy Module is now working.
  * The hardware loop has been updated for better performance.
->>>>>>> upstream/master


### PR DESCRIPTION
Remove stray Git conflict markers (<<<<<<< HEAD and >>>>>>> upstream/master) from README.md. This cleans up merge artifacts so the README renders correctly and no content was otherwise changed.

Before issuing a pull request, please see the contributing page.
